### PR TITLE
Upgrade to the latest supported Python and Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,48 @@
-language: python
-python:
-  - 2.7
-  - 3.5
-  - pypy
-before_install:
-  - pip install --upgrade pytest
-script: python setup.py test
 sudo: false
-# before_deploy: pip install clint
-deploy:
-    # test pypi
-  - provider: pypi
-    distributions: sdist bdist_wheel
-    server: https://testpypi.python.org/pypi
-    user: "mojeto"
-    password:
-      secure: "oueShjmhyJqDprlBsUlIYZFbhBQx+cWoe+AX/+7Y4254kiSmXbeFuxPnUbzSHwDb6KZ4igP7Jd7kn96i5i6xtDIrO/nzqNgnrQKTsbJhk8vIpL72zQhEBdbWBJBbFJKMpr6GpHYb1N7CYS7W243P80iIIz8oV1Ud9d4yHScy/9H7kdagCpMb5mT/uQSk3sDcsG5jcEnK5a8Ya7Djkzva66AP1Uas2+zigoYVyoyCC0HkXzk4njz8EGg1fZQEV6bbZhtJd8tOLAN+ikuThUtAM20aVtwl9a0klngHrVIEPli0eO8J4IvNxaHmMl8jH9cizbBn70IDmtIrt5WEvm/w+zzhbJfULQXGEBj8QXuppaRMAZeRBT6i7qsNgsYA2sseNKuc0ofo7FrevMzBfQRd6crO1ZhtO/7BaHVaucgpTcSLX9p05t+NIJGH1iHPygsK1TBY9wFfbS/7Ddp5F0JclOBNRBlGF3EC625cbhAzapmkIv9hSI91656p0zX1v5v7GkFiZk9JXKosb3v2gtxOQHA6JeKkoeUunsJslx4E1L8NigAx4RXaBbGaJnEeA17Uv09mqtNrMC2FrUyNquDE5KBhnWhCyi26XtWqPYNeLZcUkIeGvVuiGqeNKlBkiOAfVdStLCUZz+GV6DP+oGtVxOUb6qte9dySAC+g85gO4Rc="
-    on:
-      branch: master
-      tags: false
-      condition: $TRAVIS_PYTHON_VERSION = "2.7"
-  # pypi
-  - provider: pypi
-    distributions: sdist bdist_wheel
-    server: https://pypi.python.org/pypi
-    user: "mojeto"
-    password:
-      secure: "oueShjmhyJqDprlBsUlIYZFbhBQx+cWoe+AX/+7Y4254kiSmXbeFuxPnUbzSHwDb6KZ4igP7Jd7kn96i5i6xtDIrO/nzqNgnrQKTsbJhk8vIpL72zQhEBdbWBJBbFJKMpr6GpHYb1N7CYS7W243P80iIIz8oV1Ud9d4yHScy/9H7kdagCpMb5mT/uQSk3sDcsG5jcEnK5a8Ya7Djkzva66AP1Uas2+zigoYVyoyCC0HkXzk4njz8EGg1fZQEV6bbZhtJd8tOLAN+ikuThUtAM20aVtwl9a0klngHrVIEPli0eO8J4IvNxaHmMl8jH9cizbBn70IDmtIrt5WEvm/w+zzhbJfULQXGEBj8QXuppaRMAZeRBT6i7qsNgsYA2sseNKuc0ofo7FrevMzBfQRd6crO1ZhtO/7BaHVaucgpTcSLX9p05t+NIJGH1iHPygsK1TBY9wFfbS/7Ddp5F0JclOBNRBlGF3EC625cbhAzapmkIv9hSI91656p0zX1v5v7GkFiZk9JXKosb3v2gtxOQHA6JeKkoeUunsJslx4E1L8NigAx4RXaBbGaJnEeA17Uv09mqtNrMC2FrUyNquDE5KBhnWhCyi26XtWqPYNeLZcUkIeGvVuiGqeNKlBkiOAfVdStLCUZz+GV6DP+oGtVxOUb6qte9dySAC+g85gO4Rc="
-    on:
-      branch: master
-      tags: true
-      condition: $TRAVIS_PYTHON_VERSION = "2.7"
+language: python
+cache: pip
+
+matrix:
+  include:
+    - python: 2.7
+      env: DJANGO="Django>=1.8,<1.9"
+    - python: 3.3
+      env: DJANGO="Django>=1.8,<1.9"
+    - python: 3.4
+      env: DJANGO="Django>=1.8,<1.9"
+    - python: 3.5
+      env: DJANGO="Django>=1.8,<1.9"
+    - python: pypy
+      env: DJANGO="Django>=1.8,<1.9"
+    - python: 2.7
+      env: DJANGO="Django>=1.9,<1.10"
+    - python: 3.4
+      env: DJANGO="Django>=1.9,<1.10"
+    - python: 3.5
+      env: DJANGO="Django>=1.9,<1.10"
+    - python: pypy
+      env: DJANGO="Django>=1.9,<1.10"
+    - python: 2.7
+      env: DJANGO="Django>=1.10,<1.11"
+    - python: 3.4
+      env: DJANGO="Django>=1.10,<1.11"
+    - python: 3.5
+      env: DJANGO="Django>=1.10,<1.11"
+    - python: pypy
+      env: DJANGO="Django>=1.10,<1.11"
+    - python: 2.7
+      env: DJANGO="Django>=1.11,<2.0"
+    - python: 3.4
+      env: DJANGO="Django>=1.11,<2.0"
+    - python: 3.5
+      env: DJANGO="Django>=1.11,<2.0"
+    - python: 3.6
+      env: DJANGO="Django>=1.11,<2.0"
+    - python: pypy
+      env: DJANGO="Django>=1.11,<2.0"
+
+install:
+  - pip install --upgrade pytest
+  - pip install $DJANGO
+
+script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ matrix:
       env: DJANGO="Django>=2.1,<2.2"
 
 install:
+  - pip install --upgrade pip
   - pip install --upgrade pytest
   - pip install $DJANGO
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,32 +4,7 @@ cache: pip
 
 matrix:
   include:
-    - python: 2.7
-      env: DJANGO="Django>=1.8,<1.9"
-    - python: 3.3
-      env: DJANGO="Django>=1.8,<1.9"
-    - python: 3.4
-      env: DJANGO="Django>=1.8,<1.9"
-    - python: 3.5
-      env: DJANGO="Django>=1.8,<1.9"
-    - python: pypy
-      env: DJANGO="Django>=1.8,<1.9"
-    - python: 2.7
-      env: DJANGO="Django>=1.9,<1.10"
-    - python: 3.4
-      env: DJANGO="Django>=1.9,<1.10"
-    - python: 3.5
-      env: DJANGO="Django>=1.9,<1.10"
-    - python: pypy
-      env: DJANGO="Django>=1.9,<1.10"
-    - python: 2.7
-      env: DJANGO="Django>=1.10,<1.11"
-    - python: 3.4
-      env: DJANGO="Django>=1.10,<1.11"
-    - python: 3.5
-      env: DJANGO="Django>=1.10,<1.11"
-    - python: pypy
-      env: DJANGO="Django>=1.10,<1.11"
+    # Django 1.11
     - python: 2.7
       env: DJANGO="Django>=1.11,<2.0"
     - python: 3.4
@@ -40,9 +15,60 @@ matrix:
       env: DJANGO="Django>=1.11,<2.0"
     - python: pypy
       env: DJANGO="Django>=1.11,<2.0"
+    # Django 2.0
+    - python: 3.4
+      env: DJANGO="Django>=2.0,<2.1"
+    - python: 3.5
+      env: DJANGO="Django>=2.0,<2.1"
+    - python: 3.6
+      env: DJANGO="Django>=2.0,<2.1"
+      # https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905 python 3.7
+    - language: python
+      python: "3.7"
+      sudo: required
+      dist: xenial
+      env: DJANGO="Django>=2.0,<2.1"
+    - python: pypy3
+      env: DJANGO="Django>=2.0,<2.1"
+    # Django 2.1
+    - python: 3.5
+      env: DJANGO="Django>=2.1,<2.2"
+    - python: 3.6
+      env: DJANGO="Django>=2.1,<2.2"
+    - language: python
+      python: "3.7"
+      sudo: required
+      dist: xenial
+      env: DJANGO="Django>=2.1,<2.2"
+    - python: pypy3
+      env: DJANGO="Django>=2.1,<2.2"
 
 install:
   - pip install --upgrade pytest
   - pip install $DJANGO
 
 script: python setup.py test
+
+deploy:
+    # test pypi
+  - provider: pypi
+    distributions: sdist bdist_wheel
+    server: https://testpypi.python.org/pypi
+    user: "mojeto"
+    password:
+      secure: "oueShjmhyJqDprlBsUlIYZFbhBQx+cWoe+AX/+7Y4254kiSmXbeFuxPnUbzSHwDb6KZ4igP7Jd7kn96i5i6xtDIrO/nzqNgnrQKTsbJhk8vIpL72zQhEBdbWBJBbFJKMpr6GpHYb1N7CYS7W243P80iIIz8oV1Ud9d4yHScy/9H7kdagCpMb5mT/uQSk3sDcsG5jcEnK5a8Ya7Djkzva66AP1Uas2+zigoYVyoyCC0HkXzk4njz8EGg1fZQEV6bbZhtJd8tOLAN+ikuThUtAM20aVtwl9a0klngHrVIEPli0eO8J4IvNxaHmMl8jH9cizbBn70IDmtIrt5WEvm/w+zzhbJfULQXGEBj8QXuppaRMAZeRBT6i7qsNgsYA2sseNKuc0ofo7FrevMzBfQRd6crO1ZhtO/7BaHVaucgpTcSLX9p05t+NIJGH1iHPygsK1TBY9wFfbS/7Ddp5F0JclOBNRBlGF3EC625cbhAzapmkIv9hSI91656p0zX1v5v7GkFiZk9JXKosb3v2gtxOQHA6JeKkoeUunsJslx4E1L8NigAx4RXaBbGaJnEeA17Uv09mqtNrMC2FrUyNquDE5KBhnWhCyi26XtWqPYNeLZcUkIeGvVuiGqeNKlBkiOAfVdStLCUZz+GV6DP+oGtVxOUb6qte9dySAC+g85gO4Rc="
+    on:
+      branch: master
+      tags: false
+      condition: $TRAVIS_PYTHON_VERSION = "3.6" AND $DJANGO = "Django>=1.11,<2.0"
+  # pypi
+  - provider: pypi
+    distributions: sdist bdist_wheel
+    server: https://pypi.python.org/pypi
+    user: "mojeto"
+    password:
+      secure: "oueShjmhyJqDprlBsUlIYZFbhBQx+cWoe+AX/+7Y4254kiSmXbeFuxPnUbzSHwDb6KZ4igP7Jd7kn96i5i6xtDIrO/nzqNgnrQKTsbJhk8vIpL72zQhEBdbWBJBbFJKMpr6GpHYb1N7CYS7W243P80iIIz8oV1Ud9d4yHScy/9H7kdagCpMb5mT/uQSk3sDcsG5jcEnK5a8Ya7Djkzva66AP1Uas2+zigoYVyoyCC0HkXzk4njz8EGg1fZQEV6bbZhtJd8tOLAN+ikuThUtAM20aVtwl9a0klngHrVIEPli0eO8J4IvNxaHmMl8jH9cizbBn70IDmtIrt5WEvm/w+zzhbJfULQXGEBj8QXuppaRMAZeRBT6i7qsNgsYA2sseNKuc0ofo7FrevMzBfQRd6crO1ZhtO/7BaHVaucgpTcSLX9p05t+NIJGH1iHPygsK1TBY9wFfbS/7Ddp5F0JclOBNRBlGF3EC625cbhAzapmkIv9hSI91656p0zX1v5v7GkFiZk9JXKosb3v2gtxOQHA6JeKkoeUunsJslx4E1L8NigAx4RXaBbGaJnEeA17Uv09mqtNrMC2FrUyNquDE5KBhnWhCyi26XtWqPYNeLZcUkIeGvVuiGqeNKlBkiOAfVdStLCUZz+GV6DP+oGtVxOUb6qte9dySAC+g85gO4Rc="
+    on:
+      branch: master
+      tags: true
+      condition: $TRAVIS_PYTHON_VERSION = "3.6" AND $DJANGO = "Django>=1.11,<2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+> All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [v1.0.0](https://github.com/mojeto/django-in-request-cache/releases/tag/v1.0.0)
+
+### Changed
+
+* Removed support for Django < 1.11 
+* Added support for Django >= 1.11 (Jon Dufresne)
+* Added support for Python 3.6 and 3.7
+
+## [v0.0.6](https://github.com/mojeto/django-in-request-cache/releases/tag/v0.0.6)
+
+### Changed
+
+* Pypi wheel build added.
+
+## [v0.0.5](https://github.com/mojeto/django-in-request-cache/releases/tag/v0.0.5)
+
+### Added
+
+* CacheACache class added.
+
+## [v0.0.4](https://github.com/mojeto/django-in-request-cache/releases/tag/v0.0.4)
+
+### Changed
+
+* Fixed the bug with django cache location param.

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ CacheACache configuration
 Requirements
 ------------
 
-* `Django`_ >= 1.6
+* `Django`_ >= 1.8
 * `django-globals`_ >= 0.2
 
 

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Quick start
 
 2. Add django-globals middleware to your settings like this::
 
-    MIDDLEWARE_CLASSES = [
+    MIDDLEWARE = [
         ...,
         'django_globals.middleware.Global',
     ]
@@ -102,8 +102,8 @@ CacheACache configuration
 Requirements
 ------------
 
-* `Django`_ >= 1.8
-* `django-globals`_ >= 0.2
+* `Django`_ >= 1.11
+* `django-globals`_ >= 0.3.2
 
 
 License

--- a/django_in_request_cache/__init__.py
+++ b/django_in_request_cache/__init__.py
@@ -5,4 +5,4 @@
 
 from __future__ import unicode_literals, absolute_import
 
-__version__ = '0.0.6'
+__version__ = '1.0.0'

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 4 - Beta",
         "Environment :: Web Environment",
         "Framework :: Django",
         "Framework :: Django :: 1.11",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def find_version(*file_paths):
 
 
 install_requires = [
-    'Django>=1.6',
+    'Django>=1.8',
     'django-globals>=0.2',
 ]
 
@@ -49,11 +49,22 @@ setup(
         "Development Status :: 2 - Pre-Alpha",
         "Environment :: Web Environment",
         "Framework :: Django",
+        "Framework :: Django :: 1.8",
+        "Framework :: Django :: 1.9",
+        "Framework :: Django :: 1.10",
+        "Framework :: Django :: 1.11",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     extras_require={},
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ def find_version(*file_paths):
 
 
 install_requires = [
-    'Django>=1.8',
-    'django-globals>=0.2',
+    'Django>=1.11',
+    'django-globals>=0.3.2',
 ]
 
 
@@ -49,20 +49,20 @@ setup(
         "Development Status :: 2 - Pre-Alpha",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 1.8",
-        "Framework :: Django :: 1.9",
-        "Framework :: Django :: 1.10",
         "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.0",
+        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],


### PR DESCRIPTION
This PR is based on @jdufresne work in forgotten PR #3

It makes the package Django 1.11 and Django 2 compatible.
It limits Python versions to those compatible with given Django version.
Compatibility based on https://docs.djangoproject.com/en/2.1/faq/install/#what-python-version-can-i-use-with-django